### PR TITLE
Improve `read_until`, add `read` (read a file).

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -87,24 +87,8 @@ pub fn write_vec(v: impl AsRef<[u8]>) -> Result<(), Box<dyn Error>> {
 pub fn read<T: DeserializeOwned>() -> Result<T, Box<dyn Error>> {
     // First line should be an integer specifying how many characters the serialized object takes
     // up on the input tape.
-    let n: usize = match read_until(b'\n') {
-        Ok(bytes) => match std::str::from_utf8(&bytes) {
-            Ok(s) => match s.parse() {
-                Ok(num) => num,
-                Err(_) => {
-                    return Err(Box::new(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "Failed to parse input as usize",
-                    )));
-                }
-            },
-            Err(_) => {
-                return Err(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Failed to convert input to UTF-8",
-                )));
-            }
-        },
+    let n: usize = match read_line::<usize>() {
+        Ok(num) => num,
         Err(_) => {
             return Err(Box::new(std::io::Error::new(
                 std::io::ErrorKind::Other,

--- a/src/io.rs
+++ b/src/io.rs
@@ -56,6 +56,23 @@ where
     }
 }
 
+
+/// Mimic  std::fs::read https://doc.rust-lang.org/std/fs/fn.read.html
+/// Read from the input tape until EOF and return the contents as a Vec<u8>.
+pub fn read() -> Result<Vec<u8>, Box<dyn Error>> {
+    let mut result = Vec::new();
+    loop {
+        let input = unsafe { getchar() as u32 };
+        if input == u32::MAX {
+            // EOF reached
+            break;
+        }
+        result.push(input as u8);
+    }
+    Ok(result)
+}
+
+
 /// Read from the input tape until we hit EOF or a specific character.
 pub fn read_until(stop_char: u8) -> Result<Vec<u8>, Box<dyn Error>> {
     let mut result = Vec::new();
@@ -89,8 +106,14 @@ pub fn write_vec(v: impl AsRef<[u8]>) -> Result<(), Box<dyn Error>> {
 }
 
 /// Construct a deserializable object from bytes read off the input tape.
-pub fn read<T: DeserializeOwned>() -> Result<T, Box<dyn Error>> {
-    let bytes = read_until(u8::MAX)?;
+pub fn read_and_deserialize<T: DeserializeOwned>() -> Result<T, Box<dyn Error>> {
+    let bytes = match read() {
+        Ok(b) => b,
+        Err(e) => {
+            println(&format!("Error reading bytes: {}", e));
+            return Err(e);
+        }
+    };
     
     // Deserialize the object.
     bincode::options()

--- a/src/io.rs
+++ b/src/io.rs
@@ -44,20 +44,17 @@ pub fn println(s: &str) {
 pub fn read_line<T>() -> Result<T, Box<dyn Error>>
 where
     T: std::str::FromStr,
-    <T as std::str::FromStr>::Err: std::error::Error + 'static
+    <T as std::str::FromStr>::Err: std::error::Error + 'static,
 {
     let input = read_until(b'\n')?;
     let trimmed = std::str::from_utf8(&input)?.trim();
     match trimmed.parse() {
         Ok(value) => Ok(value),
-        Err(e) => {
-            Err(Box::new(e))
-        }
+        Err(e) => Err(Box::new(e)),
     }
 }
 
-
-/// Mimic  std::fs::read https://doc.rust-lang.org/std/fs/fn.read.html
+/// Mimic std::fs::read https://doc.rust-lang.org/std/fs/fn.read.html
 /// Read from the input tape until EOF and return the contents as a Vec<u8>.
 pub fn read() -> Result<Vec<u8>, Box<dyn Error>> {
     let mut result = Vec::new();
@@ -71,7 +68,6 @@ pub fn read() -> Result<Vec<u8>, Box<dyn Error>> {
     }
     Ok(result)
 }
-
 
 /// Read from the input tape until we hit EOF or a specific character.
 pub fn read_until(stop_char: u8) -> Result<Vec<u8>, Box<dyn Error>> {
@@ -114,7 +110,7 @@ pub fn read_and_deserialize<T: DeserializeOwned>() -> Result<T, Box<dyn Error>> 
             return Err(e);
         }
     };
-    
+
     // Deserialize the object.
     bincode::options()
         .with_fixint_encoding()

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,8 +4,8 @@ macro_rules! entrypoint {
         const DELENDUM_ENTRY: fn() = $path;
 
         mod delendum_generated_main {
-            use $crate::rand::delendum_rand;
             use $crate::getrandom::register_custom_getrandom;
+            use $crate::rand::delendum_rand;
 
             register_custom_getrandom!(delendum_rand);
 


### PR DESCRIPTION
This address problems raised by @mratsim 

>seems like this would fail with multi-lines inputs.
And also cryptographic hashes can generate \n at random

Note that the first line is the number of byte to read and it is now taken in as a usize.